### PR TITLE
md5 support for command line

### DIFF
--- a/mst/args.py
+++ b/mst/args.py
@@ -50,6 +50,11 @@ def parse_msc_args(raw_args):
                               action='count',
                               help="Use 'Dropbox' hashing algorithm instead of sha256.")
 
+    attest_group.add_argument("--md5-checksum",
+                              dest='md5_checksum',
+                              default=False,
+                              help="Use md5 hashing algorithm instead of sha256.")
+
     parser_attest.add_argument("-s", "--slot", type=int, default=0,
                               dest='slot',
                               help="Specify the slot position index.")
@@ -140,6 +145,10 @@ def parse_msc_args(raw_args):
                               action='count',
                               help="Use 'Dropbox' hashing algorithm instead of sha256.")
 
+    verify_group.add_argument("--md5-checksum",
+                              dest='md5_checksum',
+                              default=False,
+                              help="Use md5 hashing algorithm instead of sha256.")
 
     parser_verify.add_argument("-b","--bitcoin-node", dest="bitcoin_node", type=str,
                               default="https://api.blockcypher.com/v1/btc/main/txs/",

--- a/mst/cmds.py
+++ b/mst/cmds.py
@@ -556,6 +556,8 @@ def verify_command(args):
 
     if args.dropbox_checksum:
         proof_checksum = dropbox_checksum
+    elif args.md5_checksum:
+        proof_checksum = md5_checksum
     else:
         proof_checksum = sha256sum
 


### PR DESCRIPTION
Part 1 - standard sha256 method
```
# sha256sum requirements.txt 
eb9bc97eb51063947ab0eb0c5bd69c9e92f2fa4caeb83dffab160ee770b3611d  requirements.txt

# msc attest -f requirements.txt -s 5 -t api_key
No configuration file found
No private key: unsigned commitment
SHA256(requirements.txt): eb9bc97eb51063947ab0eb0c5bd69c9e92f2fa4caeb83dffab160ee770b3611d
Attestation sent
```

Part 2 - md5 method (for gdrive or others with md5)
```
# md5sum requirements.txt 
691802c212d9111001824cb013ab8ae7  requirements.txt

h = hashlib.sha256('691802c212d9111001824cb013ab8ae7'.encode('utf-8')).hexdigest()                                                                      
h : 'c99a7a7ad1e8b6ec2f4752bc33d0e18582df313786cb06a0d3ff041c0307b2f9'

# msc attest --md5-checksum requirements.txt -s 5 -t api_key
No configuration file found
No private key: unsigned commitment
SHA256 derived from MD5 hash(requirements.txt): c99a7a7ad1e8b6ec2f4752bc33d0e18582df313786cb06a0d3ff041c0307b2f9
Attestation sent
```
